### PR TITLE
Fix GetMembers and GetMemberships returning array of the same memberships. Prepare plugin for sending to verification.

### DIFF
--- a/PubnubChat.uplugin
+++ b/PubnubChat.uplugin
@@ -2,23 +2,31 @@
 	"FileVersion": 3,
 	"Version": 3,
 	"VersionName": "0.1.2",
-	"FriendlyName": "PubnubChatSDK",
-	"Description": "",
-	"Category": "Other",
-	"CreatedBy": "",
-	"CreatedByURL": "",
-	"DocsURL": "",
+	"FriendlyName": "Pubnub Chat SDK",
+	"Description": "Quickly and easily integrate a real-time text chat solution that is reliable, flexible, and scalable.",
+	"Category": "Code",
+	"CreatedBy": "PubNub Inc.",
+	"CreatedByURL": "https://www.pubnub.com/",
+	"DocsURL": "https://www.pubnub.com/docs/chat/unreal-chat-sdk/overview",
 	"MarketplaceURL": "",
 	"SupportURL": "",
 	"CanContainContent": true,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,
 	"Installed": false,
+	"SupportedTargetPlatforms": [
+		"Win64",
+		"Mac"
+	],
 	"Modules": [
 		{
 			"Name": "PubnubChatSDK",
 			"Type": "Runtime",
-			"LoadingPhase": "Default"
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Mac"
+			]
 		}
 	]
 }

--- a/Source/PubnubChatSDK/Private/FunctionLibraries/PubnubChatUtilities.cpp
+++ b/Source/PubnubChatSDK/Private/FunctionLibraries/PubnubChatUtilities.cpp
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 
 #include "FunctionLibraries/PubnubChatUtilities.h"

--- a/Source/PubnubChatSDK/Private/PubnubAccessManager.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubAccessManager.cpp
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 
 #include "PubnubAccessManager.h"

--- a/Source/PubnubChatSDK/Private/PubnubCallbackStop.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubCallbackStop.cpp
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 
 #include "PubnubCallbackStop.h"

--- a/Source/PubnubChatSDK/Private/PubnubChannel.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubChannel.cpp
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 
 #include "PubnubChannel.h"

--- a/Source/PubnubChatSDK/Private/PubnubChat.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubChat.cpp
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #include "PubnubChat.h"
 #include "PubnubUser.h"

--- a/Source/PubnubChatSDK/Private/PubnubChatSubsystem.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubChatSubsystem.cpp
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #include "PubnubChatSubsystem.h"
 

--- a/Source/PubnubChatSDK/Private/PubnubMembership.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubMembership.cpp
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 
 #include "PubnubMembership.h"

--- a/Source/PubnubChatSDK/Private/PubnubMembership.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubMembership.cpp
@@ -14,8 +14,8 @@ UPubnubMembership* UPubnubMembership::Create(Pubnub::Membership Membership)
 {
 	UPubnubMembership* NewMembership = NewObject<UPubnubMembership>();
 	NewMembership->InternalMembership = new Pubnub::Membership(Membership);
-	Channel = UPubnubChannel::Create(Membership.channel);
-	User = UPubnubUser::Create(Membership.user);
+	NewMembership->Channel = UPubnubChannel::Create(Membership.channel);
+	NewMembership->User = UPubnubUser::Create(Membership.user);
 	return NewMembership;
 }
 

--- a/Source/PubnubChatSDK/Private/PubnubMessage.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubMessage.cpp
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 
 #include "PubnubMessage.h"

--- a/Source/PubnubChatSDK/Private/PubnubThreadChannel.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubThreadChannel.cpp
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 
 #include "PubnubThreadChannel.h"

--- a/Source/PubnubChatSDK/Private/PubnubThreadMessage.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubThreadMessage.cpp
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 
 #include "PubnubThreadMessage.h"

--- a/Source/PubnubChatSDK/Private/PubnubUser.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubUser.cpp
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 
 #include "PubnubUser.h"

--- a/Source/PubnubChatSDK/Public/FunctionLibraries/PubnubChatUtilities.h
+++ b/Source/PubnubChatSDK/Public/FunctionLibraries/PubnubChatUtilities.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/PubnubChatSDK/Public/PubnubAccessManager.h
+++ b/Source/PubnubChatSDK/Public/PubnubAccessManager.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/PubnubChatSDK/Public/PubnubCallbackStop.h
+++ b/Source/PubnubChatSDK/Public/PubnubCallbackStop.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/PubnubChatSDK/Public/PubnubChannel.h
+++ b/Source/PubnubChatSDK/Public/PubnubChannel.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/PubnubChatSDK/Public/PubnubChat.h
+++ b/Source/PubnubChatSDK/Public/PubnubChat.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/PubnubChatSDK/Public/PubnubChatEnumLibrary.h
+++ b/Source/PubnubChatSDK/Public/PubnubChatEnumLibrary.h
@@ -1,3 +1,5 @@
+// Copyright 2024 PubNub Inc. All Rights Reserved.
+
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/PubnubChatSDK/Public/PubnubChatSDK.h
+++ b/Source/PubnubChatSDK/Public/PubnubChatSDK.h
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/PubnubChatSDK/Public/PubnubChatStructLibrary.h
+++ b/Source/PubnubChatSDK/Public/PubnubChatStructLibrary.h
@@ -1,3 +1,5 @@
+// Copyright 2024 PubNub Inc. All Rights Reserved.
+
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/PubnubChatSDK/Public/PubnubChatSubsystem.h
+++ b/Source/PubnubChatSDK/Public/PubnubChatSubsystem.h
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/PubnubChatSDK/Public/PubnubMembership.h
+++ b/Source/PubnubChatSDK/Public/PubnubMembership.h
@@ -62,8 +62,10 @@ public:
 
 private:
 	Pubnub::Membership* InternalMembership;
-	static inline UPubnubChannel* Channel = nullptr;
-	static inline UPubnubUser* User = nullptr;
+	UPROPERTY()
+	UPubnubChannel* Channel = nullptr;
+	UPROPERTY()
+	UPubnubUser* User = nullptr;
 	
 	bool IsInternalMembershipValid();
 	

--- a/Source/PubnubChatSDK/Public/PubnubMembership.h
+++ b/Source/PubnubChatSDK/Public/PubnubMembership.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/PubnubChatSDK/Public/PubnubMessage.h
+++ b/Source/PubnubChatSDK/Public/PubnubMessage.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/PubnubChatSDK/Public/PubnubThreadChannel.h
+++ b/Source/PubnubChatSDK/Public/PubnubThreadChannel.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/PubnubChatSDK/Public/PubnubThreadMessage.h
+++ b/Source/PubnubChatSDK/Public/PubnubThreadMessage.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/PubnubChatSDK/Public/PubnubUser.h
+++ b/Source/PubnubChatSDK/Public/PubnubUser.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/PubnubChatSDK/PubnubChatSDK.Build.cs
+++ b/Source/PubnubChatSDK/PubnubChatSDK.Build.cs
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 using UnrealBuildTool;
 

--- a/Source/ThirdParty/sdk/ChatSDKModule/ChatSDKModule.Build.cs
+++ b/Source/ThirdParty/sdk/ChatSDKModule/ChatSDKModule.Build.cs
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 using System;
 using System.IO;

--- a/Source/ThirdParty/sdk/ChatSDKModule/Private/ChatSDKModule.cpp
+++ b/Source/ThirdParty/sdk/ChatSDKModule/Private/ChatSDKModule.cpp
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #include "ChatSDKModule.h"
 #include "Modules/ModuleManager.h"

--- a/Source/ThirdParty/sdk/ChatSDKModule/Public/ChatSDK.h
+++ b/Source/ThirdParty/sdk/ChatSDKModule/Public/ChatSDK.h
@@ -1,3 +1,5 @@
+// Copyright 2024 PubNub Inc. All Rights Reserved.
+
 THIRD_PARTY_INCLUDES_START
 #include "pubnub_chat/chat.hpp"
 THIRD_PARTY_INCLUDES_END

--- a/Source/ThirdParty/sdk/ChatSDKModule/Public/ChatSDKModule.h
+++ b/Source/ThirdParty/sdk/ChatSDKModule/Public/ChatSDKModule.h
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright 2024 PubNub Inc. All Rights Reserved.
 
 #pragma once
 


### PR DESCRIPTION
As the title says, there is a major bug fixed about GetMembers and GetMemberships returning incorrect array of memberships.
-Added all necessary data to .uplugin
-Added copyright statements to all code files