### PR TITLE
Initializing UPROPERTY members

### DIFF
--- a/Source/PubnubChatSDK/Public/PubnubChannel.h
+++ b/Source/PubnubChatSDK/Public/PubnubChannel.h
@@ -33,7 +33,7 @@ struct FPubnubMembersResponseWrapper
 	
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") TArray<UPubnubMembership*> Memberships;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FPubnubPage Page;
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total = 0;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FString Status;
 
 	FPubnubMembersResponseWrapper() = default;
@@ -48,7 +48,7 @@ struct FPubnubUsersRestrictionsWrapper
 	
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") TArray<FPubnubUserRestriction> Restrictions;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FPubnubPage Page;
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total = 0;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FString Status;
 
 	FPubnubUsersRestrictionsWrapper() = default;
@@ -62,7 +62,7 @@ struct FPubnubMessageReportsHistoryWrapper
 	GENERATED_BODY();
 
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") TArray<FPubnubEvent> Events;
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") bool IsMore;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") bool IsMore = false;
 
 	FPubnubMessageReportsHistoryWrapper() = default;
 	FPubnubMessageReportsHistoryWrapper(Pubnub::EventsHistoryWrapper& Wrapper) :

--- a/Source/PubnubChatSDK/Public/PubnubChat.h
+++ b/Source/PubnubChatSDK/Public/PubnubChat.h
@@ -26,9 +26,9 @@ struct FPubnubUnreadMessageWrapper
 {
 	GENERATED_BODY()
 
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubChannel* Channel;
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubMembership* Membership;
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Count;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubChannel* Channel = nullptr;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubMembership* Membership = nullptr;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Count = 0;
 
 	FPubnubUnreadMessageWrapper() = default;
 	FPubnubUnreadMessageWrapper(Pubnub::UnreadMessageWrapper& MessageWrapper) :
@@ -46,8 +46,8 @@ struct FPubnubMarkMessagesAsReadWrapper
 	GENERATED_BODY();
 	
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FPubnubPage Page;
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total;
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Status;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total = 0;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Status = 0;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") TArray<UPubnubMembership*> Memberships;
 
 	FPubnubMarkMessagesAsReadWrapper() = default;
@@ -69,8 +69,8 @@ struct FPubnubCreatedChannelWrapper
 {
 	GENERATED_BODY();
 
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubChannel* CreatedChannel;
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubMembership* HostMembership;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubChannel* CreatedChannel = nullptr;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubMembership* HostMembership = nullptr;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") TArray<UPubnubMembership*> InviteesMemberships;
 
 	FPubnubCreatedChannelWrapper() = default;
@@ -93,7 +93,7 @@ struct FPubnubChannelsResponseWrapper
 	
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") TArray<UPubnubChannel*> Channels;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FPubnubPage Page;
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total = 0;
 
 	FPubnubChannelsResponseWrapper() = default;
 	FPubnubChannelsResponseWrapper(Pubnub::ChannelsResponseWrapper& Wrapper) :
@@ -116,7 +116,7 @@ struct FPubnubUsersResponseWrapper
 	
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") TArray<UPubnubUser*> Users;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FPubnubPage Page;
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total = 0;
 
 	FPubnubUsersResponseWrapper() = default;
 	FPubnubUsersResponseWrapper(Pubnub::UsersResponseWrapper& Wrapper) :
@@ -138,7 +138,7 @@ struct FPubnubEventsHistoryWrapper
 	GENERATED_BODY();
 
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") TArray<FPubnubEvent> Events;
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") bool IsMore;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") bool IsMore = false;
 
 	FPubnubEventsHistoryWrapper() = default;
 	FPubnubEventsHistoryWrapper(Pubnub::EventsHistoryWrapper& Wrapper) :
@@ -162,7 +162,7 @@ struct FPubnubUserMentionData
     UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FString ChannelID;
     UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FString UserID;
     UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FPubnubEvent Event;
-    UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubMessage* Message;
+    UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubMessage* Message = nullptr;
 
     UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FString ParentChannelID;
     UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FString ThreadChannelID;
@@ -184,7 +184,7 @@ struct FPubnubUserMentionDataList
     GENERATED_BODY();
 
     UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") TArray<FPubnubUserMentionData> UserMentions;
-    UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") bool IsMore;
+    UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") bool IsMore = false;
 
     FPubnubUserMentionDataList() = default;
     FPubnubUserMentionDataList(Pubnub::UserMentionDataList& MentionDataList) :

--- a/Source/PubnubChatSDK/Public/PubnubChatStructLibrary.h
+++ b/Source/PubnubChatSDK/Public/PubnubChatStructLibrary.h
@@ -396,7 +396,7 @@ struct FPubnubEvent
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FString Timetoken = "";
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") EPubnubChatEventType Type;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") EPubnubChatEventType Type = EPubnubChatEventType::PCET_CUSTOM;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FString ChannelID = "";
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FString UserID = "";
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FString Payload = "";

--- a/Source/PubnubChatSDK/Public/PubnubChatStructLibrary.h
+++ b/Source/PubnubChatSDK/Public/PubnubChatStructLibrary.h
@@ -419,7 +419,7 @@ struct FPubnubSendTextParams
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") bool StoreInHistory = true;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") bool SendByPost = false;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FString Meta = "";
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubMessage* QuotedMessage;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubMessage* QuotedMessage = nullptr;
 
 	FPubnubSendTextParams() = default;
 

--- a/Source/PubnubChatSDK/Public/PubnubUser.h
+++ b/Source/PubnubChatSDK/Public/PubnubUser.h
@@ -22,7 +22,7 @@ struct FPubnubMembershipsResponseWrapper
 	
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") TArray<UPubnubMembership*> Memberships;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FPubnubPage Page;
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total = 0;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FString Status;
 
 	FPubnubMembershipsResponseWrapper() = default;
@@ -37,7 +37,7 @@ struct FPubnubChannelsRestrictionsWrapper
 	
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") TArray<FPubnubChannelRestriction> Restrictions;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FPubnubPage Page;
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Total = 0;
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") FString Status;
 
 	FPubnubChannelsRestrictionsWrapper() = default;


### PR DESCRIPTION
Unreal complains when UPROPERTY members have no default values:
```
Error        LogClass                  EnumProperty FPubnubEvent::Type is not initialized properly. Module:PubnubChatSDK [File:Public/PubnubChatStructLibrary.h](file:///PubnubChatStructLibrary.h)
Error        LogClass                  ObjectProperty FSendTextParams::QuotedMessage is not initialized properly. Module:PubnubChatSDK [File:Public/PubnubChannel.h](file:///PubnubChannel.h)
Error        LogClass                  IntProperty FPubnubMembersResponseWrapper::Total is not initialized properly. Module:PubnubChatSDK [File:Public/PubnubChannel.h](file:///PubnubChannel.h)
[...]
```
These errors get in the way of readability, so it's better to initialize everything.