### PR TITLE
Fix compilation errors for UE versions not using c++20.

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -3,6 +3,13 @@ version: 1.0.1
 schema: 1
 scm: github.com/pubnub/unreal-engine-chat
 changelog:
+  - date: 2026-04-20
+    version: 1.0.1
+    changes:
+      - type: bug
+        text: "Fix compilation errors when C++ 20 support is not enabled by replace designated initializers."
+      - type: bug
+        text: "Fix not initialized properly errors printed for some UStruct properties."
   - date: 2026-04-02
     version: 1.0.0
     changes:

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,5 @@
 name: unreal-engine-chat
-version: 1.0.0
+version: 1.0.1
 schema: 1
 scm: github.com/pubnub/unreal-engine-chat
 changelog:

--- a/PubnubChat.uplugin
+++ b/PubnubChat.uplugin
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"Version": 21,
+	"Version": 22,
 	"VersionName": "1.0.0",
 	"FriendlyName": "Pubnub Chat SDK",
 	"Description": "Quickly and easily integrate a real-time text chat solution that is reliable, flexible, and scalable.",
@@ -8,7 +8,7 @@
 	"CreatedBy": "PubNub Inc.",
 	"CreatedByURL": "https://www.pubnub.com/",
 	"DocsURL": "https://www.pubnub.com/docs/chat/unreal-chat-sdk/build/configuration",
-	"FabURL": "com.epicgames.launcher://ue/Fab/product/69e7b3b4-6ef4-4c1c-b84a-0029c8ae63ae",
+	"FabURL": "com.epicgames.launcher://ue/Fab/product/6ec392de-0ef9-4645-9ca9-2c5a928edadb",
 	"SupportURL": "",
 	"CanContainContent": true,
 	"IsBetaVersion": false,

--- a/PubnubChat.uplugin
+++ b/PubnubChat.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 22,
-	"VersionName": "1.0.0",
+	"VersionName": "1.0.1",
 	"FriendlyName": "Pubnub Chat SDK",
 	"Description": "Quickly and easily integrate a real-time text chat solution that is reliable, flexible, and scalable.",
 	"Category": "Code",

--- a/Source/PubnubChatSDK/Private/PubnubChat.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubChat.cpp
@@ -900,7 +900,10 @@ FPubnubChatWhoIsPresentResult UPubnubChat::WhoIsPresent(const FString ChannelID,
 	PUBNUB_CHAT_RETURN_WRAPPER_IF_FIELD_EMPTY(FinalResult, ChannelID);
 	
 	//Use PubnubClient ListUserSubscribedChannels (WhereNow) to get all subscribed channels
-	FPubnubListUsersFromChannelSettings HereNowSettings = FPubnubListUsersFromChannelSettings{.DisableUserID = false, .Limit = Limit, .Offset = Offset};
+	FPubnubListUsersFromChannelSettings HereNowSettings;
+	HereNowSettings.DisableUserID = false;
+	HereNowSettings.Limit = Limit;
+	HereNowSettings.Offset = Offset;
 	FPubnubListUsersFromChannelResult HereNowResult = PubnubClient->ListUsersFromChannel(ChannelID, HereNowSettings);
 	PUBNUB_CHAT_ADD_PUBNUB_RESULT_AND_RETURN_WRAPPER_IF_ERROR(FinalResult, HereNowResult.Result, "ListUserSubscribedChannels");
 	

--- a/Source/PubnubChatSDK/Private/PubnubChatChannel.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubChatChannel.cpp
@@ -320,7 +320,10 @@ FPubnubChatInviteResult UPubnubChatChannel::Invite(UPubnubChatUser* User)
 
 	//GetChannelMembers from PubnubClient to check if the user is not already member of that channel
 	FString Filter = UPubnubChatInternalUtilities::GetFilterForUserID(User->GetUserID());
-	FPubnubMemberInclude Include = FPubnubMemberInclude({.IncludeCustom=true, .IncludeStatus=true, .IncludeType=true});
+	FPubnubMemberInclude Include;
+	Include.IncludeCustom = true;
+	Include.IncludeStatus = true;
+	Include.IncludeType = true;
 	FPubnubChannelMembersResult GetChannelMembersResult = PubnubClient->GetChannelMembers(ChannelID, Include, 1, Filter);
 	PUBNUB_CHAT_ADD_PUBNUB_RESULT_AND_RETURN_WRAPPER_IF_ERROR(FinalResult, GetChannelMembersResult.Result, "GetChannelMembers");
 	
@@ -332,7 +335,8 @@ FPubnubChatInviteResult UPubnubChatChannel::Invite(UPubnubChatUser* User)
 	}
 
 	//Create Membership with "pending" status
-	FPubnubChatMembershipData MembershipData = FPubnubChatMembershipData{.Status = Pubnub_Chat_Invited_User_Membership_status};
+	FPubnubChatMembershipData MembershipData;
+	MembershipData.Status = Pubnub_Chat_Invited_User_Membership_status;
 	
 	//SetMemberships by PubnubClient
 	FPubnubMembershipsResult SetMembershipResult = PubnubClient->SetMemberships(User->GetUserID(), {MembershipData.ToPubnubMembershipInputData(ChannelID)}, FPubnubMembershipInclude::FromValue(false), 1);
@@ -390,7 +394,8 @@ FPubnubChatInviteMultipleResult UPubnubChatChannel::InviteMultiple(TArray<UPubnu
 	FString Filter = UPubnubChatInternalUtilities::GetFilterForMultipleUsersID(ValidUsers);
 	TArray<FPubnubChannelMemberInputData> MembersInput;
 	//Create Membership with "pending" status
-	FPubnubChatMembershipData MembershipData = FPubnubChatMembershipData{.Status = Pubnub_Chat_Invited_User_Membership_status};
+	FPubnubChatMembershipData MembershipData;
+	MembershipData.Status = Pubnub_Chat_Invited_User_Membership_status;
 
 	for(auto& User : ValidUsers)
 	{
@@ -1007,7 +1012,10 @@ FPubnubChatGetRestrictionResult UPubnubChatChannel::GetUserRestrictions(UPubnubC
 	}
 	else
 	{
-		FinalResult.Restriction = FPubnubChatRestriction({.UserID = User->GetUserID(), .ChannelID = ChannelID});
+		FPubnubChatRestriction Restriction;
+		Restriction.UserID = User->GetUserID();
+		Restriction.ChannelID = ChannelID;
+		FinalResult.Restriction = Restriction;
 	}
 	
 	return FinalResult;
@@ -2338,7 +2346,9 @@ FPubnubChatGetRestrictionsResult UPubnubChatChannel::GetRestrictions(const int L
 	
 	//Getting restrictions is actually getting members from moderation channel
 	FString ModerationChannelID = UPubnubChatInternalUtilities::GetRestrictionsChannelForChannelID(ChannelID);
-	FPubnubMemberInclude Include = FPubnubMemberInclude({.IncludeCustom = true, .IncludeTotalCount = true}); 
+	FPubnubMemberInclude Include;
+	Include.IncludeCustom = true;
+	Include.IncludeTotalCount = true;
 	FPubnubChannelMembersResult GetMembersResult = PubnubClient->GetChannelMembers(ModerationChannelID, Include, Limit, Filter, Sort, Page);
 	PUBNUB_CHAT_ADD_PUBNUB_RESULT_AND_RETURN_WRAPPER_IF_ERROR(FinalResult, GetMembersResult.Result, "GetChannelMembers");
 	

--- a/Source/PubnubChatSDK/Private/PubnubChatMessageDraft.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubChatMessageDraft.cpp
@@ -39,7 +39,10 @@ FPubnubChatOperationResult UPubnubChatMessageDraft::InsertText(int Position, con
 		
 		TriggerTypingIndicator();
 		
-		FPubnubChatMessageElement NewElement = FPubnubChatMessageElement({.Text = Text, .Start = 0, .Length = Text.Len()});
+		FPubnubChatMessageElement NewElement;
+		NewElement.Text = Text;
+		NewElement.Start = 0;
+		NewElement.Length = Text.Len();
 		MessageElements.Add(NewElement);
 		FireMessageDraftChangedDelegate();
 		return FinalResult;
@@ -122,7 +125,10 @@ FPubnubChatOperationResult UPubnubChatMessageDraft::InsertText(int Position, con
 		
 		//Neither of those are text ones, so create new text MessageElement - reorder existing ones first
 		MoveMessageElementsAfterPosition(Position, Text.Len(), true);
-		FPubnubChatMessageElement NewElement = FPubnubChatMessageElement({.Text = Text, .Start = Position, .Length = Text.Len()});
+		FPubnubChatMessageElement NewElement;
+		NewElement.Text = Text;
+		NewElement.Start = Position;
+		NewElement.Length = Text.Len();
 		MessageElements.Insert(NewElement, MessageElementIndex);
 		FireMessageDraftChangedDelegate();
 		return FinalResult;
@@ -140,7 +146,10 @@ FPubnubChatOperationResult UPubnubChatMessageDraft::InsertText(int Position, con
 	}
 	
 	// Or if last MessageElement is not a text one, just create new one and add it at the end
-	FPubnubChatMessageElement NewElement = FPubnubChatMessageElement({.Text = Text, .Start = Position, .Length = Text.Len()});
+	FPubnubChatMessageElement NewElement;
+	NewElement.Text = Text;
+	NewElement.Start = Position;
+	NewElement.Length = Text.Len();
 	MessageElements.Add(NewElement);
 	FireMessageDraftChangedDelegate();
 	return FinalResult;
@@ -247,7 +256,11 @@ FPubnubChatOperationResult UPubnubChatMessageDraft::AddMention(int Position, int
 			if (Position == ElementStart)
 			{
 				//Create new Mention element at the start
-				FPubnubChatMessageElement MentionElement = FPubnubChatMessageElement({.MentionTarget = MentionTarget, .Text = MentionText, .Start = Position, .Length = Length});
+				FPubnubChatMessageElement MentionElement;
+				MentionElement.MentionTarget = MentionTarget;
+				MentionElement.Text = MentionText;
+				MentionElement.Start = Position;
+				MentionElement.Length = Length;
 				
 				//Remove the mention part from original element
 				Element.RemoveText(0, Length);
@@ -268,9 +281,21 @@ FPubnubChatOperationResult UPubnubChatMessageDraft::AddMention(int Position, int
 				FString TextAfter = Element.Text.Mid(PositionInElement + Length);
 				
 				//Create three elements: text before, mention, text after
-				FPubnubChatMessageElement TextBeforeElement = FPubnubChatMessageElement({.MentionTarget = FPubnubChatMentionTarget(), .Text = TextBefore, .Start = ElementStart, .Length = PositionInElement});
-				FPubnubChatMessageElement MentionElement = FPubnubChatMessageElement({.MentionTarget = MentionTarget, .Text = MentionText, .Start = Position, .Length = Length});
-				FPubnubChatMessageElement TextAfterElement = FPubnubChatMessageElement({.MentionTarget = FPubnubChatMentionTarget(), .Text = TextAfter, .Start = Position + Length, .Length = ElementEnd - MentionEnd});
+				FPubnubChatMessageElement TextBeforeElement;
+				TextBeforeElement.MentionTarget = FPubnubChatMentionTarget();
+				TextBeforeElement.Text = TextBefore;
+				TextBeforeElement.Start = ElementStart;
+				TextBeforeElement.Length = PositionInElement;
+				FPubnubChatMessageElement MentionElement;
+				MentionElement.MentionTarget = MentionTarget;
+				MentionElement.Text = MentionText;
+				MentionElement.Start = Position;
+				MentionElement.Length = Length;
+				FPubnubChatMessageElement TextAfterElement;
+				TextAfterElement.MentionTarget = FPubnubChatMentionTarget();
+				TextAfterElement.Text = TextAfter;
+				TextAfterElement.Start = Position + Length;
+				TextAfterElement.Length = ElementEnd - MentionEnd;
 				
 				//Remove original element and insert the three new elements
 				MessageElements.RemoveAt(i);
@@ -289,7 +314,11 @@ FPubnubChatOperationResult UPubnubChatMessageDraft::AddMention(int Position, int
 				Element.RemoveText(PositionInElement, Length);
 				
 				//Create new Mention element at the end
-				FPubnubChatMessageElement MentionElement = FPubnubChatMessageElement({.MentionTarget = MentionTarget, .Text = MentionText, .Start = Position, .Length = Length});
+				FPubnubChatMessageElement MentionElement;
+				MentionElement.MentionTarget = MentionTarget;
+				MentionElement.Text = MentionText;
+				MentionElement.Start = Position;
+				MentionElement.Length = Length;
 				
 				//Insert the mention element after the updated original element
 				MessageElements.Insert(MentionElement, i + 1);
@@ -1137,7 +1166,10 @@ FPubnubChatOperationResult UPubnubChatMessageDraft::Update(const FString& NewTex
 		//Use internal insertion without delegate firing
 		if (MessageElements.IsEmpty())
 		{
-			FPubnubChatMessageElement NewElement = FPubnubChatMessageElement({.Text = TextToInsert, .Start = 0, .Length = TextToInsert.Len()});
+			FPubnubChatMessageElement NewElement;
+			NewElement.Text = TextToInsert;
+			NewElement.Start = 0;
+			NewElement.Length = TextToInsert.Len();
 			MessageElements.Add(NewElement);
 		}
 		else
@@ -1179,7 +1211,10 @@ FPubnubChatOperationResult UPubnubChatMessageDraft::Update(const FString& NewTex
 			}
 			
 			//Create new element
-			FPubnubChatMessageElement NewElement = FPubnubChatMessageElement({.Text = TextToInsert, .Start = ChangeStart, .Length = TextToInsert.Len()});
+			FPubnubChatMessageElement NewElement;
+			NewElement.Text = TextToInsert;
+			NewElement.Start = ChangeStart;
+			NewElement.Length = TextToInsert.Len();
 			MessageElements.Insert(NewElement, InsertIndex);
 			MoveMessageElementsAfterPosition(ChangeStart, TextToInsert.Len(), false);
 		}

--- a/Source/PubnubChatSDK/Private/PubnubChatUser.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubChatUser.cpp
@@ -422,7 +422,10 @@ FPubnubChatGetRestrictionResult UPubnubChatUser::GetChannelRestrictions(UPubnubC
 	}
 	else
 	{
-		FinalResult.Restriction = FPubnubChatRestriction({.UserID = UserID, .ChannelID = Channel->GetChannelID()});
+		FPubnubChatRestriction Restriction;
+		Restriction.UserID = UserID;
+		Restriction.ChannelID = Channel->GetChannelID();
+		FinalResult.Restriction = Restriction;
 	}
 	
 	return FinalResult;
@@ -1020,7 +1023,9 @@ FPubnubChatGetRestrictionsResult UPubnubChatUser::GetRestrictions(const int Limi
 {
 	FPubnubChatGetRestrictionsResult FinalResult;
 	
-	FPubnubMembershipInclude Include = FPubnubMembershipInclude({.IncludeCustom = true, .IncludeTotalCount = true}); 
+	FPubnubMembershipInclude Include;
+	Include.IncludeCustom = true;
+	Include.IncludeTotalCount = true;
 	FPubnubMembershipsResult GetMembershipsResult = PubnubClient->GetMemberships(UserID, Include, Limit, Filter, Sort, Page);
 	PUBNUB_CHAT_ADD_PUBNUB_RESULT_AND_RETURN_WRAPPER_IF_ERROR(FinalResult, GetMembershipsResult.Result, "GetMemberships");
 	

--- a/Source/PubnubChatSDK/Public/PubnubChatVersion.h
+++ b/Source/PubnubChatSDK/Public/PubnubChatVersion.h
@@ -4,7 +4,7 @@
 
 #define PUBNUB_CHAT_VERSION_MAJOR 1
 #define PUBNUB_CHAT_VERSION_MINOR 0
-#define PUBNUB_CHAT_VERSION_PATCH 0
+#define PUBNUB_CHAT_VERSION_PATCH 1
 #define PUBNUB_CHAT_VERSION ((PUBNUB_CHAT_VERSION_MAJOR * 10000) + (PUBNUB_CHAT_VERSION_MINOR * 100) + PUBNUB_CHAT_VERSION_PATCH)
 
 /** Minimum PubnubLibrary version required. Bump when Chat needs API from a newer PubnubLibrary. Encoding: (major*10000)+(minor*100)+patch. */

--- a/Source/PubnubChatSDK/Public/StructLibraries/PubnubChatChannelStructLibrary.h
+++ b/Source/PubnubChatSDK/Public/StructLibraries/PubnubChatChannelStructLibrary.h
@@ -222,7 +222,7 @@ struct FPubnubChatCreateDirectConversationResult
 	/** The membership of the user who initiated the conversation. */
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubChatMembership* HostMembership = nullptr;
 	/** The membership of the other user in the direct conversation. */
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubChatMembership* InviteeMembership;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubChatMembership* InviteeMembership = nullptr;
 };
 
 /**

--- a/Source/PubnubChatSDK/Public/StructLibraries/PubnubChatStructLibrary.h
+++ b/Source/PubnubChatSDK/Public/StructLibraries/PubnubChatStructLibrary.h
@@ -579,9 +579,9 @@ struct FPubnubChatUnreadMessagesCountsWrapper
 	GENERATED_BODY()
 	
 	/** The channel with unread messages. */
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubChatChannel* Channel;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubChatChannel* Channel = nullptr;
 	/** The user's membership for this channel (contains last read position). */
-	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubChatMembership* Membership;
+	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") UPubnubChatMembership* Membership = nullptr;
 	/** Number of unread messages in the channel. */
 	UPROPERTY(BlueprintReadWrite, VisibleAnywhere, Category = "PubnubChat") int Count = 0;
 };


### PR DESCRIPTION
fix: Fix compilation errors when C++ 20 support is not enabled.

Fix compilation errors when C++ 20 support is not enabled by replace designated initializers.

fix: not initialized properly errors.

Fix not initialized properly errors printed for some UStruct properties.