### PR TITLE
Address security scan reported issues.

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,17 @@
 name: unreal-engine-chat
-version: 1.0.2
+version: 1.0.3
 schema: 1
 scm: github.com/pubnub/unreal-engine-chat
 changelog:
+  - date: 2026-06-23
+    version: 1.0.3
+    changes:
+      - type: bug
+        text: "Fix dangling pointer race in `PubnubChatObjectsRepository` getters."
+      - type: improvement
+        text: "Remove leftover `bEnableExceptions`."
+      - type: improvement
+        text: "Add proper JSON serialization in places where unescaped `FString::Printf` was used."
   - date: 2026-04-28
     version: 1.0.2
     changes:

--- a/PubnubChat.uplugin
+++ b/PubnubChat.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 24,
-	"VersionName": "1.0.2",
+	"VersionName": "1.0.3",
 	"FriendlyName": "Pubnub Chat SDK",
 	"Description": "Quickly and easily integrate a real-time text chat solution that is reliable, flexible, and scalable.",
 	"Category": "Code",

--- a/PubnubChat.uplugin
+++ b/PubnubChat.uplugin
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"Version": 23,
+	"Version": 24,
 	"VersionName": "1.0.2",
 	"FriendlyName": "Pubnub Chat SDK",
 	"Description": "Quickly and easily integrate a real-time text chat solution that is reliable, flexible, and scalable.",

--- a/Scripts/prepare_for_release_chat.py
+++ b/Scripts/prepare_for_release_chat.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Prepare the Pubnub Chat Unreal SDK for release.
+
+Updates:
+  - PubnubChat.uplugin: increments Version (VersionName is unchanged)
+  - PubnubChatVersion.h: sets PUBNUB_CHAT_VERSION_{MAJOR,MINOR,PATCH}
+    and optionally PUBNUB_CHAT_REQUIRES_LIBRARY_VERSION
+
+Run from any directory; paths are resolved from script location.
+
+CLI examples:
+  python prepare_for_release_chat.py --release-version 1.0.3
+  python prepare_for_release_chat.py -r 1.0.3 --required-pubnub-sdk-version 2.0.5
+  python prepare_for_release_chat.py -r 1.0.3 --required-pubnub-sdk-version
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+_VERSION_PATTERN = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def _parse_semver(label: str, value: str) -> tuple[int, int, int]:
+    match = _VERSION_PATTERN.match(value.strip())
+    if not match:
+        raise ValueError(f"{label} must be in MAJOR.MINOR.PATCH format (e.g. 1.0.2), got: {value!r}")
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def _encode_version(major: int, minor: int, patch: int) -> int:
+    return (major * 10000) + (minor * 100) + patch
+
+
+def _prompt(label: str, *, required: bool = True) -> str:
+    while True:
+        value = input(f"{label}: ").strip()
+        if value or not required:
+            return value
+        print("  Value is required.")
+
+
+def _resolve_input(label: str, arg_value: str | None, *, required: bool = True) -> str:
+    if arg_value is not None:
+        return arg_value.strip()
+    return _prompt(label, required=required)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prepare the Pubnub Chat Unreal SDK for release.")
+    parser.add_argument(
+        "-r",
+        "--release-version",
+        help="Release version in MAJOR.MINOR.PATCH format. Prompts when omitted.",
+    )
+    parser.add_argument(
+        "-l",
+        "--required-pubnub-sdk-version",
+        nargs="?",
+        const="",
+        default=None,
+        help=(
+            "Required Pubnub SDK version in MAJOR.MINOR.PATCH format. "
+            "Omit the flag to prompt; pass the flag alone to skip updating."
+        ),
+    )
+    return parser
+
+
+def _update_uplugin_version(uplugin_path: Path) -> int:
+    with uplugin_path.open("r", encoding="utf-8") as f:
+        uplugin = json.load(f)
+
+    old_version = uplugin.get("Version")
+    if not isinstance(old_version, int):
+        raise SystemExit(f"Unexpected Version field in {uplugin_path}: {old_version!r}")
+
+    new_version = old_version + 1
+    uplugin["Version"] = new_version
+
+    with uplugin_path.open("w", encoding="utf-8", newline="\n") as f:
+        json.dump(uplugin, f, indent="\t")
+        f.write("\n")
+
+    return new_version
+
+
+def _update_version_header(
+    header_path: Path,
+    major: int,
+    minor: int,
+    patch: int,
+    required_library_version: int | None,
+) -> None:
+    content = header_path.read_text(encoding="utf-8")
+
+    content, count = re.subn(
+        r"(#define PUBNUB_CHAT_VERSION_MAJOR )\d+",
+        rf"\g<1>{major}",
+        content,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit(f"Could not update PUBNUB_CHAT_VERSION_MAJOR in {header_path}")
+
+    content, count = re.subn(
+        r"(#define PUBNUB_CHAT_VERSION_MINOR )\d+",
+        rf"\g<1>{minor}",
+        content,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit(f"Could not update PUBNUB_CHAT_VERSION_MINOR in {header_path}")
+
+    content, count = re.subn(
+        r"(#define PUBNUB_CHAT_VERSION_PATCH )\d+",
+        rf"\g<1>{patch}",
+        content,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit(f"Could not update PUBNUB_CHAT_VERSION_PATCH in {header_path}")
+
+    if required_library_version is not None:
+        content, count = re.subn(
+            r"(#define PUBNUB_CHAT_REQUIRES_LIBRARY_VERSION )\d+",
+            rf"\g<1>{required_library_version}",
+            content,
+            count=1,
+        )
+        if count != 1:
+            raise SystemExit(f"Could not update PUBNUB_CHAT_REQUIRES_LIBRARY_VERSION in {header_path}")
+
+    header_path.write_text(content, encoding="utf-8", newline="\n")
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _build_arg_parser().parse_args(argv)
+
+    script_dir = Path(__file__).resolve().parent
+    plugin_root = script_dir.parent
+    uplugin_path = plugin_root / "PubnubChat.uplugin"
+    header_path = plugin_root / "Source" / "PubnubChatSDK" / "Public" / "PubnubChatVersion.h"
+
+    if not uplugin_path.is_file():
+        raise SystemExit(f"Plugin descriptor not found: {uplugin_path}")
+    if not header_path.is_file():
+        raise SystemExit(f"Version header not found: {header_path}")
+
+    print("Prepare Pubnub Chat Unreal SDK for release\n")
+
+    release_version = _resolve_input("Release version (MAJOR.MINOR.PATCH)", args.release_version)
+    try:
+        major, minor, patch = _parse_semver("Release version", release_version)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    library_input = _resolve_input(
+        "Required Pubnub SDK version (MAJOR.MINOR.PATCH, leave empty to skip)",
+        args.required_pubnub_sdk_version,
+        required=False,
+    )
+    required_library_version: int | None = None
+    required_library_version_str: str | None = None
+    if library_input:
+        try:
+            lib_major, lib_minor, lib_patch = _parse_semver("Required Pubnub SDK version", library_input)
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
+        required_library_version = _encode_version(lib_major, lib_minor, lib_patch)
+        required_library_version_str = f"{lib_major}.{lib_minor}.{lib_patch}"
+
+    release_version_str = f"{major}.{minor}.{patch}"
+
+    new_uplugin_version = _update_uplugin_version(uplugin_path)
+    _update_version_header(header_path, major, minor, patch, required_library_version)
+
+    print("\nUpdated files:")
+    print(f"  {uplugin_path}")
+    print(f"    Version -> {new_uplugin_version} (VersionName unchanged)")
+    print(f"  {header_path}")
+    print(f"    PUBNUB_CHAT_VERSION -> {release_version_str}")
+    if required_library_version is not None:
+        print(
+            f"    PUBNUB_CHAT_REQUIRES_LIBRARY_VERSION -> {required_library_version}"
+            f" ({required_library_version_str})"
+        )
+    else:
+        print("    PUBNUB_CHAT_REQUIRES_LIBRARY_VERSION -> unchanged")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nAborted.", file=sys.stderr)
+        sys.exit(130)

--- a/Source/PubnubChatSDK/Private/FunctionLibraries/PubnubChatInternalUtilities.cpp
+++ b/Source/PubnubChatSDK/Private/FunctionLibraries/PubnubChatInternalUtilities.cpp
@@ -18,7 +18,7 @@
 
 FString UPubnubChatInternalUtilities::GetFilterForUserID(const FString& UserID)
 {
-	return FString::Printf(TEXT("uuid.id == \"%s\""), *UserID);
+	return FString::Printf(TEXT("uuid.id == %s"), *UPubnubJsonUtilities::SerializeString(UserID));
 }
 
 FString UPubnubChatInternalUtilities::GetFilterForMultipleUsersID(const TArray<UPubnubChatUser*>& Users)
@@ -32,19 +32,21 @@ FString UPubnubChatInternalUtilities::GetFilterForMultipleUsersID(const TArray<U
 		{
 			FinalFilter.Append(" || ");
 		}
-		FinalFilter.Append(FString::Printf(TEXT(R"(uuid.id == "%s")"), *User->GetUserID()));
+		FinalFilter.Append(FString::Printf(TEXT("uuid.id == %s"), *UPubnubJsonUtilities::SerializeString(User->GetUserID())));
 	}
 	return FinalFilter;
 }
 
 FString UPubnubChatInternalUtilities::GetFilterForChannelID(const FString& ChannelID)
 {
-	return FString::Printf(TEXT("channel.id == \"%s\""), *ChannelID);
+	return FString::Printf(TEXT("channel.id == %s"), *UPubnubJsonUtilities::SerializeString(ChannelID));
 }
 
 FString UPubnubChatInternalUtilities::GetFilterForChannelsRestrictions()
 {
-	return FString::Printf(TEXT("channel.id LIKE \"%s*\""), *Pubnub_Chat_Moderation_Channel_Prefix);
+	return FString::Printf(
+		TEXT("channel.id LIKE %s"),
+		*UPubnubJsonUtilities::SerializeString(Pubnub_Chat_Moderation_Channel_Prefix + TEXT("*")));
 }
 
 FString UPubnubChatInternalUtilities::GetChatSdkVersionSuffix()
@@ -392,17 +394,26 @@ FPubnubChatCustomEvent UPubnubChatInternalUtilities::GetCustomEventFromPubnubMes
 
 FString UPubnubChatInternalUtilities::GetReceiptEventPayload(const FString& Timetoken)
 {
-	return FString::Printf(TEXT(R"({"messageTimetoken": "%s"})"), *Timetoken);
+	TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
+	JsonObject->SetStringField(ANSI_TO_TCHAR("messageTimetoken"), Timetoken);
+	return UPubnubJsonUtilities::JsonObjectToString(JsonObject);
 }
 
 FString UPubnubChatInternalUtilities::GetInviteEventPayload(const FString ChannelID, const FString ChannelType)
 {
-	return FString::Printf(TEXT(R"({"channelType": "%s", "channelId": "%s"})"), *ChannelType, *ChannelID);
+	TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
+	JsonObject->SetStringField(ANSI_TO_TCHAR("channelType"), ChannelType);
+	JsonObject->SetStringField(ANSI_TO_TCHAR("channelId"), ChannelID);
+	return UPubnubJsonUtilities::JsonObjectToString(JsonObject);
 }
 
 FString UPubnubChatInternalUtilities::GetModerationEventPayload(const FString ModerationChannel, const FString RestrictionType, const FString Reason)
 {
-	return FString::Printf(TEXT(R"({"channelId": "%s", "restriction": "%s", "reason": "%s"})"), *ModerationChannel, *RestrictionType, *Reason);
+	TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
+	JsonObject->SetStringField(ANSI_TO_TCHAR("channelId"), ModerationChannel);
+	JsonObject->SetStringField(ANSI_TO_TCHAR("restriction"), RestrictionType);
+	JsonObject->SetStringField(ANSI_TO_TCHAR("reason"), Reason);
+	return UPubnubJsonUtilities::JsonObjectToString(JsonObject);
 }
 
 bool UPubnubChatInternalUtilities::IsThisEventMessage(const FString& MessageContent)

--- a/Source/PubnubChatSDK/Private/PubnubChatChannel.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubChatChannel.cpp
@@ -41,10 +41,10 @@ FPubnubChatChannelData UPubnubChatChannel::GetChannelData() const
 {
 	PUBNUB_CHAT_OBJECT_RETURN_IF_NOT_INITIALIZED(FPubnubChatChannelData());
 
-	//Get channel data from repository
-	if (FPubnubChatInternalChannel* InternalChannel = Chat->ObjectsRepository->GetChannelData(ChannelID))
+	FPubnubChatChannelData ChannelData;
+	if (Chat->ObjectsRepository->TryGetChannelData(ChannelID, ChannelData))
 	{
-		return InternalChannel->ChannelData;
+		return ChannelData;
 	}
 
 	UE_LOG(PubnubChatLog, Error, TEXT("Channel data not found in repository for ChannelID: %s"), *ChannelID);

--- a/Source/PubnubChatSDK/Private/PubnubChatMembership.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubChatMembership.cpp
@@ -40,10 +40,10 @@ FPubnubChatMembershipData UPubnubChatMembership::GetMembershipData() const
 {
 	PUBNUB_CHAT_OBJECT_RETURN_IF_NOT_INITIALIZED(FPubnubChatMembershipData());
 
-	// Get membership data from repository
-	if (FPubnubChatInternalMembership* InternalMembership = Chat->ObjectsRepository->GetMembershipData(GetInternalMembershipID()))
+	FPubnubChatMembershipData MembershipData;
+	if (Chat->ObjectsRepository->TryGetMembershipData(GetInternalMembershipID(), MembershipData))
 	{
-		return InternalMembership->MembershipData;
+		return MembershipData;
 	}
 
 	FString UserIDStr = User ? User->GetUserID() : TEXT("");

--- a/Source/PubnubChatSDK/Private/PubnubChatMessage.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubChatMessage.cpp
@@ -37,11 +37,10 @@ FPubnubChatMessageData UPubnubChatMessage::GetMessageData() const
 {
 	PUBNUB_CHAT_OBJECT_RETURN_IF_NOT_INITIALIZED(FPubnubChatMessageData());
 
-	// Get message data from repository
-	FPubnubChatInternalMessage* InternalMessage = Chat->ObjectsRepository->GetMessageData(GetInternalMessageID());
-	if (InternalMessage)
+	FPubnubChatMessageData MessageData;
+	if (Chat->ObjectsRepository->TryGetMessageData(GetInternalMessageID(), MessageData))
 	{
-		return InternalMessage->MessageData;
+		return MessageData;
 	}
 
 	UE_LOG(PubnubChatLog, Error, TEXT("Message data not found in repository for ChannelID: %s, Timetoken: %s"), *ChannelID, *Timetoken);

--- a/Source/PubnubChatSDK/Private/PubnubChatObjectsRepository.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubChatObjectsRepository.cpp
@@ -106,10 +106,15 @@ void UPubnubChatObjectsRepository::UnregisterChannel(const FString& ChannelID)
 	}
 }
 
-FPubnubChatInternalUser* UPubnubChatObjectsRepository::GetUserData(const FString& UserID)
+bool UPubnubChatObjectsRepository::TryGetUserData(const FString& UserID, FPubnubChatUserData& OutUserData) const
 {
 	FScopeLock Lock(&UsersCriticalSection);
-	return Users.Find(UserID);
+	if (const FPubnubChatInternalUser* InternalUser = Users.Find(UserID))
+	{
+		OutUserData = InternalUser->UserData;
+		return true;
+	}
+	return false;
 }
 
 void UPubnubChatObjectsRepository::UpdateUserData(const FString& UserID, const FPubnubChatUserData& UserData)
@@ -134,10 +139,15 @@ bool UPubnubChatObjectsRepository::RemoveUserData(const FString& UserID)
 	return Users.Remove(UserID) > 0;
 }
 
-FPubnubChatInternalChannel* UPubnubChatObjectsRepository::GetChannelData(const FString& ChannelID)
+bool UPubnubChatObjectsRepository::TryGetChannelData(const FString& ChannelID, FPubnubChatChannelData& OutChannelData) const
 {
 	FScopeLock Lock(&ChannelsCriticalSection);
-	return Channels.Find(ChannelID);
+	if (const FPubnubChatInternalChannel* InternalChannel = Channels.Find(ChannelID))
+	{
+		OutChannelData = InternalChannel->ChannelData;
+		return true;
+	}
+	return false;
 }
 
 void UPubnubChatObjectsRepository::UpdateChannelData(const FString& ChannelID, const FPubnubChatChannelData& ChannelData)
@@ -213,10 +223,15 @@ void UPubnubChatObjectsRepository::UnregisterMessage(const FString& MessageID)
 	}
 }
 
-FPubnubChatInternalMessage* UPubnubChatObjectsRepository::GetMessageData(const FString& MessageID)
+bool UPubnubChatObjectsRepository::TryGetMessageData(const FString& MessageID, FPubnubChatMessageData& OutMessageData) const
 {
 	FScopeLock Lock(&MessagesCriticalSection);
-	return Messages.Find(MessageID);
+	if (const FPubnubChatInternalMessage* InternalMessage = Messages.Find(MessageID))
+	{
+		OutMessageData = InternalMessage->MessageData;
+		return true;
+	}
+	return false;
 }
 
 void UPubnubChatObjectsRepository::UpdateMessageData(const FString& MessageID, const FPubnubChatMessageData& MessageData)
@@ -292,10 +307,15 @@ void UPubnubChatObjectsRepository::UnregisterMembership(const FString& Membershi
 	}
 }
 
-FPubnubChatInternalMembership* UPubnubChatObjectsRepository::GetMembershipData(const FString& MembershipID)
+bool UPubnubChatObjectsRepository::TryGetMembershipData(const FString& MembershipID, FPubnubChatMembershipData& OutMembershipData) const
 {
 	FScopeLock Lock(&MembershipsCriticalSection);
-	return Memberships.Find(MembershipID);
+	if (const FPubnubChatInternalMembership* InternalMembership = Memberships.Find(MembershipID))
+	{
+		OutMembershipData = InternalMembership->MembershipData;
+		return true;
+	}
+	return false;
 }
 
 void UPubnubChatObjectsRepository::UpdateMembershipData(const FString& MembershipID, const FPubnubChatMembershipData& MembershipData)

--- a/Source/PubnubChatSDK/Private/PubnubChatObjectsRepository.h
+++ b/Source/PubnubChatSDK/Private/PubnubChatObjectsRepository.h
@@ -59,11 +59,12 @@ public:
 	void UnregisterChannel(const FString& ChannelID);
 
 	/**
-	 * Gets user data from the repository. Returns nullptr if not found.
+	 * Copies user data from the repository under lock.
 	 * @param UserID The unique identifier of the user
-	 * @return Pointer to the internal user data, or nullptr if not found
+	 * @param OutUserData Receives a copy of the stored user data when found
+	 * @return True if the user exists in the repository, false otherwise
 	 */
-	FPubnubChatInternalUser* GetUserData(const FString& UserID);
+	bool TryGetUserData(const FString& UserID, FPubnubChatUserData& OutUserData) const;
 
 	/**
 	 * Updates user data in the repository. Creates entry if it doesn't exist.
@@ -80,11 +81,12 @@ public:
 	bool RemoveUserData(const FString& UserID);
 	
 	/**
-	 * Gets channel data from the repository. Returns nullptr if not found.
+	 * Copies channel data from the repository under lock.
 	 * @param ChannelID The unique identifier of the channel
-	 * @return Pointer to the internal channel data, or nullptr if not found
+	 * @param OutChannelData Receives a copy of the stored channel data when found
+	 * @return True if the channel exists in the repository, false otherwise
 	 */
-	FPubnubChatInternalChannel* GetChannelData(const FString& ChannelID);
+	bool TryGetChannelData(const FString& ChannelID, FPubnubChatChannelData& OutChannelData) const;
 
 	/**
 	 * Updates channel data in the repository. Creates entry if it doesn't exist.
@@ -115,11 +117,12 @@ public:
 	void UnregisterMessage(const FString& MessageID);
 	
 	/**
-	 * Gets message data from the repository. Returns nullptr if not found.
+	 * Copies message data from the repository under lock.
 	 * @param MessageID The composite unique identifier of the message in format "[ChannelID].[Timetoken]"
-	 * @return Pointer to the internal message data, or nullptr if not found
+	 * @param OutMessageData Receives a copy of the stored message data when found
+	 * @return True if the message exists in the repository, false otherwise
 	 */
-	FPubnubChatInternalMessage* GetMessageData(const FString& MessageID);
+	bool TryGetMessageData(const FString& MessageID, FPubnubChatMessageData& OutMessageData) const;
 
 	/**
 	 * Updates message data in the repository. Creates entry if it doesn't exist.
@@ -150,11 +153,12 @@ public:
 	void UnregisterMembership(const FString& MembershipID);
 
 	/**
-	 * Gets membership data from the repository. Returns nullptr if not found.
+	 * Copies membership data from the repository under lock.
 	 * @param MembershipID The composite unique identifier of the membership in format "[UserID].[ChannelID]"
-	 * @return Pointer to the internal membership data, or nullptr if not found
+	 * @param OutMembershipData Receives a copy of the stored membership data when found
+	 * @return True if the membership exists in the repository, false otherwise
 	 */
-	FPubnubChatInternalMembership* GetMembershipData(const FString& MembershipID);
+	bool TryGetMembershipData(const FString& MembershipID, FPubnubChatMembershipData& OutMembershipData) const;
 
 	/**
 	 * Updates membership data in the repository. Creates entry if it doesn't exist.

--- a/Source/PubnubChatSDK/Private/PubnubChatUser.cpp
+++ b/Source/PubnubChatSDK/Private/PubnubChatUser.cpp
@@ -31,10 +31,10 @@ FPubnubChatUserData UPubnubChatUser::GetUserData() const
 {
 	PUBNUB_CHAT_OBJECT_RETURN_IF_NOT_INITIALIZED(FPubnubChatUserData());
 
-	// Get user data from repository
-	if (FPubnubChatInternalUser* InternalUser = Chat->ObjectsRepository->GetUserData(UserID))
+	FPubnubChatUserData UserData;
+	if (Chat->ObjectsRepository->TryGetUserData(UserID, UserData))
 	{
-		return InternalUser->UserData;
+		return UserData;
 	}
 
 	UE_LOG(PubnubChatLog, Error, TEXT("User data not found in repository for UserID: %s"), *UserID);

--- a/Source/PubnubChatSDK/Public/PubnubChatVersion.h
+++ b/Source/PubnubChatSDK/Public/PubnubChatVersion.h
@@ -4,7 +4,7 @@
 
 #define PUBNUB_CHAT_VERSION_MAJOR 1
 #define PUBNUB_CHAT_VERSION_MINOR 0
-#define PUBNUB_CHAT_VERSION_PATCH 2
+#define PUBNUB_CHAT_VERSION_PATCH 3
 #define PUBNUB_CHAT_VERSION ((PUBNUB_CHAT_VERSION_MAJOR * 10000) + (PUBNUB_CHAT_VERSION_MINOR * 100) + PUBNUB_CHAT_VERSION_PATCH)
 
 /** Minimum PubnubLibrary version required. Bump when Chat needs API from a newer PubnubLibrary. Encoding: (major*10000)+(minor*100)+patch. */

--- a/Source/PubnubChatSDK/PubnubChatSDK.Build.cs
+++ b/Source/PubnubChatSDK/PubnubChatSDK.Build.cs
@@ -8,8 +8,6 @@ public class PubnubChatSDK : ModuleRules
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 		
-		bEnableExceptions = true;
-		
 		PublicIncludePaths.AddRange(
 			new string[] {
 				// ... add public include paths required here ...

--- a/Source/PubnubChatSDKTests/Private/Samples/Sample_ChatSubsystem.cpp
+++ b/Source/PubnubChatSDKTests/Private/Samples/Sample_ChatSubsystem.cpp
@@ -35,7 +35,7 @@ void ASample_ChatSubsystem::InitChatWithConfigSample()
 	// Create config with  AuthKey and enable Chat to store user activity
 	FPubnubChatConfig Config;
 	Config.AuthKey = TEXT("p0F2AkF0GmheUpNDdHRsGDxDcmVzpURjaGFuoWtnbG9iYWxfY2hhdANDZ3JwoENzcGOgQ3VzcqBEdXVpZKBDcGF0pURjaGFuoENncnCgQ3NwY6BDdXNyoER1dWlkoERtZXRhoENzaWdYILa9OLrP_dhe31sW_seO2r9KhD6mp9Yi9vZxcX9QY04R");
-	Config.StoreUserActivityInterval = true;
+	Config.StoreUserActivityTimestamps = true;
 	
 	// Initialize Chat - InitChat may fail under some conditions so make sure to check the Result for errors before using the Chat
 	FPubnubChatInitChatResult InitChatResult = PubnubChatSubsystem->InitChat(TEXT("demo"), TEXT("demo"), TEXT("Player_001"), Config);

--- a/Source/PubnubChatSDKTests/Private/Tests/PubnubChatRepositoryUnitTests.cpp
+++ b/Source/PubnubChatSDKTests/Private/Tests/PubnubChatRepositoryUnitTests.cpp
@@ -34,13 +34,8 @@ bool FPubnubChatRepositoryUserRegistrationTest::RunTest(const FString& Parameter
 	Repository->RegisterUser(TestUserID);
 	
 	// Verify data exists after registration
-	FPubnubChatInternalUser* UserData = Repository->GetUserData(TestUserID);
-	TestNotNull("User data should exist after registration", UserData);
-	
-	if(UserData)
-	{
-		TestEqual("UserID should match", UserData->UserID, TestUserID);
-	}
+	FPubnubChatUserData UserData;
+	TestTrue("User data should exist after registration", Repository->TryGetUserData(TestUserID, UserData));
 	
 	return true;
 }
@@ -65,23 +60,20 @@ bool FPubnubChatRepositoryUserMultipleRegistrationTest::RunTest(const FString& P
 	Repository->RegisterUser(TestUserID);
 	
 	// Data should still exist (not cleaned up)
-	FPubnubChatInternalUser* UserData = Repository->GetUserData(TestUserID);
-	TestNotNull("User data should exist after multiple registrations", UserData);
+	FPubnubChatUserData UserData;
+	TestTrue("User data should exist after multiple registrations", Repository->TryGetUserData(TestUserID, UserData));
 	
 	// Unregister once - data should still exist
 	Repository->UnregisterUser(TestUserID);
-	UserData = Repository->GetUserData(TestUserID);
-	TestNotNull("User data should still exist after one unregistration", UserData);
+	TestTrue("User data should still exist after one unregistration", Repository->TryGetUserData(TestUserID, UserData));
 	
 	// Unregister second time - data should still exist
 	Repository->UnregisterUser(TestUserID);
-	UserData = Repository->GetUserData(TestUserID);
-	TestNotNull("User data should still exist after two unregistrations", UserData);
+	TestTrue("User data should still exist after two unregistrations", Repository->TryGetUserData(TestUserID, UserData));
 	
 	// Unregister third time - data should be cleaned up
 	Repository->UnregisterUser(TestUserID);
-	UserData = Repository->GetUserData(TestUserID);
-	TestNull("User data should be cleaned up when reference count reaches 0", UserData);
+	TestFalse("User data should be cleaned up when reference count reaches 0", Repository->TryGetUserData(TestUserID, UserData));
 	
 	return true;
 }
@@ -111,28 +103,19 @@ bool FPubnubChatRepositoryUserDataPersistenceTest::RunTest(const FString& Parame
 	Repository->UpdateUserData(TestUserID, TestData);
 	
 	// Verify data is stored
-	FPubnubChatInternalUser* UserData = Repository->GetUserData(TestUserID);
-	TestNotNull("User data should exist", UserData);
-	
-	if(UserData)
-	{
-		TestEqual("UserName should match", UserData->UserData.UserName, TestData.UserName);
-		TestEqual("Email should match", UserData->UserData.Email, TestData.Email);
-		TestEqual("ProfileUrl should match", UserData->UserData.ProfileUrl, TestData.ProfileUrl);
-	}
+	FPubnubChatUserData UserData;
+	TestTrue("User data should exist", Repository->TryGetUserData(TestUserID, UserData));
+	TestEqual("UserName should match", UserData.UserName, TestData.UserName);
+	TestEqual("Email should match", UserData.Email, TestData.Email);
+	TestEqual("ProfileUrl should match", UserData.ProfileUrl, TestData.ProfileUrl);
 	
 	// Register again (simulating second object with same ID)
 	Repository->RegisterUser(TestUserID);
 	
 	// Data should still be there and unchanged
-	UserData = Repository->GetUserData(TestUserID);
-	TestNotNull("User data should still exist after second registration", UserData);
-	
-	if(UserData)
-	{
-		TestEqual("UserName should still match after second registration", UserData->UserData.UserName, TestData.UserName);
-		TestEqual("Email should still match after second registration", UserData->UserData.Email, TestData.Email);
-	}
+	TestTrue("User data should still exist after second registration", Repository->TryGetUserData(TestUserID, UserData));
+	TestEqual("UserName should still match after second registration", UserData.UserName, TestData.UserName);
+	TestEqual("Email should still match after second registration", UserData.Email, TestData.Email);
 	
 	return true;
 }
@@ -158,12 +141,10 @@ bool FPubnubChatRepositoryUserDataSharingTest::RunTest(const FString& Parameters
 	InitialData.UserName = TEXT("InitialUser");
 	Repository->UpdateUserData(TestUserID, InitialData);
 	
-	// Get data reference
-	FPubnubChatInternalUser* DataRef1 = Repository->GetUserData(TestUserID);
-	TestNotNull("User data has to be valid", DataRef1);
-	if (!DataRef1)
-	{ return false;}
-	TestEqual("First reference should see initial data", DataRef1->UserData.UserName, InitialData.UserName);
+	// Get data copy
+	FPubnubChatUserData DataRef1;
+	TestTrue("User data has to be valid", Repository->TryGetUserData(TestUserID, DataRef1));
+	TestEqual("First reference should see initial data", DataRef1.UserName, InitialData.UserName);
 	
 	// Register again (simulating second object)
 	Repository->RegisterUser(TestUserID);
@@ -174,23 +155,16 @@ bool FPubnubChatRepositoryUserDataSharingTest::RunTest(const FString& Parameters
 	UpdatedData.Email = TEXT("updated@example.com");
 	Repository->UpdateUserData(TestUserID, UpdatedData);
 	
-	// Both references should see updated data
-	FPubnubChatInternalUser* DataPtr1 = Repository->GetUserData(TestUserID);
-	FPubnubChatInternalUser* DataPtr2 = Repository->GetUserData(TestUserID);
-	
-	TestNotNull("DataPtr1 should exist", DataPtr1);
-	TestNotNull("DataPtr2 should exist", DataPtr2);
-	
-	if(DataPtr1 && DataPtr2)
-	{
-		TestEqual("DataPtr1 should see updated UserName", DataPtr1->UserData.UserName, UpdatedData.UserName);
-		TestEqual("DataPtr2 should see updated UserName", DataPtr2->UserData.UserName, UpdatedData.UserName);
-		TestEqual("DataPtr1 should see updated Email", DataPtr1->UserData.Email, UpdatedData.Email);
-		TestEqual("DataPtr2 should see updated Email", DataPtr2->UserData.Email, UpdatedData.Email);
-		
-		// Verify they point to the same data (same memory address)
-		TestEqual("Both pointers should point to same data", DataPtr1, DataPtr2);
-	}
+	// Both reads should see updated data
+	FPubnubChatUserData DataPtr1;
+	FPubnubChatUserData DataPtr2;
+	TestTrue("DataPtr1 should exist", Repository->TryGetUserData(TestUserID, DataPtr1));
+	TestTrue("DataPtr2 should exist", Repository->TryGetUserData(TestUserID, DataPtr2));
+	TestEqual("DataPtr1 should see updated UserName", DataPtr1.UserName, UpdatedData.UserName);
+	TestEqual("DataPtr2 should see updated UserName", DataPtr2.UserName, UpdatedData.UserName);
+	TestEqual("DataPtr1 should see updated Email", DataPtr1.Email, UpdatedData.Email);
+	TestEqual("DataPtr2 should see updated Email", DataPtr2.Email, UpdatedData.Email);
+	TestEqual("Both reads should return same UserName", DataPtr1.UserName, DataPtr2.UserName);
 	
 	return true;
 }
@@ -216,15 +190,14 @@ bool FPubnubChatRepositoryUserCleanupTest::RunTest(const FString& Parameters)
 	Repository->UpdateUserData(TestUserID, TestData);
 	
 	// Verify data exists
-	FPubnubChatInternalUser* UserData = Repository->GetUserData(TestUserID);
-	TestNotNull("User data should exist before cleanup", UserData);
+	FPubnubChatUserData UserData;
+	TestTrue("User data should exist before cleanup", Repository->TryGetUserData(TestUserID, UserData));
 	
 	// Unregister - should clean up data
 	Repository->UnregisterUser(TestUserID);
 	
 	// Verify data is cleaned up
-	UserData = Repository->GetUserData(TestUserID);
-	TestNull("User data should be cleaned up after unregistration", UserData);
+	TestFalse("User data should be cleaned up after unregistration", Repository->TryGetUserData(TestUserID, UserData));
 	
 	return true;
 }
@@ -241,10 +214,11 @@ bool FPubnubChatRepositoryUserEdgeCasesTest::RunTest(const FString& Parameters)
 		return false;
 	}
 	
+	FPubnubChatUserData UserData;
+	
 	// Test 1: Register with empty ID - should handle gracefully
 	Repository->RegisterUser(TEXT(""));
-	FPubnubChatInternalUser* EmptyData = Repository->GetUserData(TEXT(""));
-	TestNull("Empty UserID should not create data", EmptyData);
+	TestFalse("Empty UserID should not create data", Repository->TryGetUserData(TEXT(""), UserData));
 	
 	// Test 2: Unregister non-existent user - should handle gracefully
 	Repository->UnregisterUser(TEXT("non_existent_user"));
@@ -262,8 +236,7 @@ bool FPubnubChatRepositoryUserEdgeCasesTest::RunTest(const FString& Parameters)
 	// Should not crash
 	
 	// Test 5: Get data for non-existent user
-	FPubnubChatInternalUser* NonExistentData = Repository->GetUserData(TEXT("non_existent"));
-	TestNull("Non-existent user should return nullptr", NonExistentData);
+	TestFalse("Non-existent user should not be found", Repository->TryGetUserData(TEXT("non_existent"), UserData));
 	
 	return true;
 }
@@ -286,13 +259,8 @@ bool FPubnubChatRepositoryChannelRegistrationTest::RunTest(const FString& Parame
 	Repository->RegisterChannel(TestChannelID);
 	
 	// Verify data exists after registration
-	FPubnubChatInternalChannel* ChannelData = Repository->GetChannelData(TestChannelID);
-	TestNotNull("Channel data should exist after registration", ChannelData);
-	
-	if(ChannelData)
-	{
-		TestEqual("ChannelID should match", ChannelData->ChannelID, TestChannelID);
-	}
+	FPubnubChatChannelData ChannelData;
+	TestTrue("Channel data should exist after registration", Repository->TryGetChannelData(TestChannelID, ChannelData));
 	
 	return true;
 }
@@ -317,19 +285,17 @@ bool FPubnubChatRepositoryChannelMultipleRegistrationTest::RunTest(const FString
 	Repository->RegisterChannel(TestChannelID);
 	
 	// Data should still exist
-	FPubnubChatInternalChannel* ChannelData = Repository->GetChannelData(TestChannelID);
-	TestNotNull("Channel data should exist after multiple registrations", ChannelData);
+	FPubnubChatChannelData ChannelData;
+	TestTrue("Channel data should exist after multiple registrations", Repository->TryGetChannelData(TestChannelID, ChannelData));
 	
 	// Unregister twice - data should still exist
 	Repository->UnregisterChannel(TestChannelID);
 	Repository->UnregisterChannel(TestChannelID);
-	ChannelData = Repository->GetChannelData(TestChannelID);
-	TestNotNull("Channel data should still exist after two unregistrations", ChannelData);
+	TestTrue("Channel data should still exist after two unregistrations", Repository->TryGetChannelData(TestChannelID, ChannelData));
 	
 	// Unregister third time - data should be cleaned up
 	Repository->UnregisterChannel(TestChannelID);
-	ChannelData = Repository->GetChannelData(TestChannelID);
-	TestNull("Channel data should be cleaned up when reference count reaches 0", ChannelData);
+	TestFalse("Channel data should be cleaned up when reference count reaches 0", Repository->TryGetChannelData(TestChannelID, ChannelData));
 	
 	return true;
 }
@@ -355,13 +321,8 @@ bool FPubnubChatRepositoryMessageRegistrationTest::RunTest(const FString& Parame
 	Repository->RegisterMessage(CompositeMessageID);
 	
 	// Verify data exists after registration
-	FPubnubChatInternalMessage* MessageData = Repository->GetMessageData(CompositeMessageID);
-	TestNotNull("Message data should exist after registration", MessageData);
-	
-	if(MessageData)
-	{
-		TestEqual("MessageID should match", MessageData->MessageID, CompositeMessageID);
-	}
+	FPubnubChatMessageData MessageData;
+	TestTrue("Message data should exist after registration", Repository->TryGetMessageData(CompositeMessageID, MessageData));
 	
 	return true;
 }
@@ -388,23 +349,20 @@ bool FPubnubChatRepositoryMessageMultipleRegistrationTest::RunTest(const FString
 	Repository->RegisterMessage(CompositeMessageID);
 	
 	// Data should still exist (not cleaned up)
-	FPubnubChatInternalMessage* MessageData = Repository->GetMessageData(CompositeMessageID);
-	TestNotNull("Message data should exist after multiple registrations", MessageData);
+	FPubnubChatMessageData MessageData;
+	TestTrue("Message data should exist after multiple registrations", Repository->TryGetMessageData(CompositeMessageID, MessageData));
 	
 	// Unregister once - data should still exist
 	Repository->UnregisterMessage(CompositeMessageID);
-	MessageData = Repository->GetMessageData(CompositeMessageID);
-	TestNotNull("Message data should still exist after one unregistration", MessageData);
+	TestTrue("Message data should still exist after one unregistration", Repository->TryGetMessageData(CompositeMessageID, MessageData));
 	
 	// Unregister second time - data should still exist
 	Repository->UnregisterMessage(CompositeMessageID);
-	MessageData = Repository->GetMessageData(CompositeMessageID);
-	TestNotNull("Message data should still exist after two unregistrations", MessageData);
+	TestTrue("Message data should still exist after two unregistrations", Repository->TryGetMessageData(CompositeMessageID, MessageData));
 	
 	// Unregister third time - data should be cleaned up
 	Repository->UnregisterMessage(CompositeMessageID);
-	MessageData = Repository->GetMessageData(CompositeMessageID);
-	TestNull("Message data should be cleaned up when reference count reaches 0", MessageData);
+	TestFalse("Message data should be cleaned up when reference count reaches 0", Repository->TryGetMessageData(CompositeMessageID, MessageData));
 	
 	return true;
 }
@@ -437,29 +395,20 @@ bool FPubnubChatRepositoryMessageDataPersistenceTest::RunTest(const FString& Par
 	Repository->UpdateMessageData(CompositeMessageID, TestData);
 	
 	// Verify data is stored
-	FPubnubChatInternalMessage* MessageData = Repository->GetMessageData(CompositeMessageID);
-	TestNotNull("Message data should exist", MessageData);
-	
-	if(MessageData)
-	{
-		TestEqual("Text should match", MessageData->MessageData.Text, TestData.Text);
-		TestEqual("ChannelID should match", MessageData->MessageData.ChannelID, TestData.ChannelID);
-		TestEqual("UserID should match", MessageData->MessageData.UserID, TestData.UserID);
-		TestEqual("Meta should match", MessageData->MessageData.Meta, TestData.Meta);
-	}
+	FPubnubChatMessageData MessageData;
+	TestTrue("Message data should exist", Repository->TryGetMessageData(CompositeMessageID, MessageData));
+	TestEqual("Text should match", MessageData.Text, TestData.Text);
+	TestEqual("ChannelID should match", MessageData.ChannelID, TestData.ChannelID);
+	TestEqual("UserID should match", MessageData.UserID, TestData.UserID);
+	TestEqual("Meta should match", MessageData.Meta, TestData.Meta);
 	
 	// Register again (simulating second object with same composite ID)
 	Repository->RegisterMessage(CompositeMessageID);
 	
 	// Data should still be there and unchanged
-	MessageData = Repository->GetMessageData(CompositeMessageID);
-	TestNotNull("Message data should still exist after second registration", MessageData);
-	
-	if(MessageData)
-	{
-		TestEqual("Text should still match after second registration", MessageData->MessageData.Text, TestData.Text);
-		TestEqual("ChannelID should still match after second registration", MessageData->MessageData.ChannelID, TestData.ChannelID);
-	}
+	TestTrue("Message data should still exist after second registration", Repository->TryGetMessageData(CompositeMessageID, MessageData));
+	TestEqual("Text should still match after second registration", MessageData.Text, TestData.Text);
+	TestEqual("ChannelID should still match after second registration", MessageData.ChannelID, TestData.ChannelID);
 	
 	return true;
 }
@@ -488,12 +437,10 @@ bool FPubnubChatRepositoryMessageDataSharingTest::RunTest(const FString& Paramet
 	InitialData.ChannelID = TestChannelID;
 	Repository->UpdateMessageData(CompositeMessageID, InitialData);
 	
-	// Get data reference
-	FPubnubChatInternalMessage* DataRef1 = Repository->GetMessageData(CompositeMessageID);
-	TestNotNull("Message data has to be valid", DataRef1);
-	if (!DataRef1)
-	{ return false;}
-	TestEqual("First reference should see initial data", DataRef1->MessageData.Text, InitialData.Text);
+	// Get data copy
+	FPubnubChatMessageData DataRef1;
+	TestTrue("Message data has to be valid", Repository->TryGetMessageData(CompositeMessageID, DataRef1));
+	TestEqual("First reference should see initial data", DataRef1.Text, InitialData.Text);
 	
 	// Register again (simulating second object)
 	Repository->RegisterMessage(CompositeMessageID);
@@ -505,23 +452,16 @@ bool FPubnubChatRepositoryMessageDataSharingTest::RunTest(const FString& Paramet
 	UpdatedData.UserID = TEXT("test_user_updated");
 	Repository->UpdateMessageData(CompositeMessageID, UpdatedData);
 	
-	// Both references should see updated data
-	FPubnubChatInternalMessage* DataPtr1 = Repository->GetMessageData(CompositeMessageID);
-	FPubnubChatInternalMessage* DataPtr2 = Repository->GetMessageData(CompositeMessageID);
-	
-	TestNotNull("DataPtr1 should exist", DataPtr1);
-	TestNotNull("DataPtr2 should exist", DataPtr2);
-	
-	if(DataPtr1 && DataPtr2)
-	{
-		TestEqual("DataPtr1 should see updated Text", DataPtr1->MessageData.Text, UpdatedData.Text);
-		TestEqual("DataPtr2 should see updated Text", DataPtr2->MessageData.Text, UpdatedData.Text);
-		TestEqual("DataPtr1 should see updated UserID", DataPtr1->MessageData.UserID, UpdatedData.UserID);
-		TestEqual("DataPtr2 should see updated UserID", DataPtr2->MessageData.UserID, UpdatedData.UserID);
-		
-		// Verify they point to the same data (same memory address)
-		TestEqual("Both pointers should point to same data", DataPtr1, DataPtr2);
-	}
+	// Both reads should see updated data
+	FPubnubChatMessageData DataPtr1;
+	FPubnubChatMessageData DataPtr2;
+	TestTrue("DataPtr1 should exist", Repository->TryGetMessageData(CompositeMessageID, DataPtr1));
+	TestTrue("DataPtr2 should exist", Repository->TryGetMessageData(CompositeMessageID, DataPtr2));
+	TestEqual("DataPtr1 should see updated Text", DataPtr1.Text, UpdatedData.Text);
+	TestEqual("DataPtr2 should see updated Text", DataPtr2.Text, UpdatedData.Text);
+	TestEqual("DataPtr1 should see updated UserID", DataPtr1.UserID, UpdatedData.UserID);
+	TestEqual("DataPtr2 should see updated UserID", DataPtr2.UserID, UpdatedData.UserID);
+	TestEqual("Both reads should return same Text", DataPtr1.Text, DataPtr2.Text);
 	
 	return true;
 }
@@ -550,15 +490,14 @@ bool FPubnubChatRepositoryMessageCleanupTest::RunTest(const FString& Parameters)
 	Repository->UpdateMessageData(CompositeMessageID, TestData);
 	
 	// Verify data exists
-	FPubnubChatInternalMessage* MessageData = Repository->GetMessageData(CompositeMessageID);
-	TestNotNull("Message data should exist before cleanup", MessageData);
+	FPubnubChatMessageData MessageData;
+	TestTrue("Message data should exist before cleanup", Repository->TryGetMessageData(CompositeMessageID, MessageData));
 	
 	// Unregister - should clean up data
 	Repository->UnregisterMessage(CompositeMessageID);
 	
 	// Verify data is cleaned up
-	MessageData = Repository->GetMessageData(CompositeMessageID);
-	TestNull("Message data should be cleaned up after unregistration", MessageData);
+	TestFalse("Message data should be cleaned up after unregistration", Repository->TryGetMessageData(CompositeMessageID, MessageData));
 	
 	return true;
 }
@@ -575,10 +514,11 @@ bool FPubnubChatRepositoryMessageEdgeCasesTest::RunTest(const FString& Parameter
 		return false;
 	}
 	
+	FPubnubChatMessageData MessageData;
+	
 	// Test 1: Register with empty composite ID - should handle gracefully
 	Repository->RegisterMessage(TEXT(""));
-	FPubnubChatInternalMessage* EmptyData = Repository->GetMessageData(TEXT(""));
-	TestNull("Empty composite MessageID should not create data", EmptyData);
+	TestFalse("Empty composite MessageID should not create data", Repository->TryGetMessageData(TEXT(""), MessageData));
 	
 	// Test 2: Unregister non-existent message - should handle gracefully
 	const FString NonExistentChannelID = TEXT("non_existent_channel");
@@ -601,20 +541,14 @@ bool FPubnubChatRepositoryMessageEdgeCasesTest::RunTest(const FString& Parameter
 	// Should not crash
 	
 	// Test 5: Get data for non-existent message
-	FPubnubChatInternalMessage* NonExistentData = Repository->GetMessageData(NonExistentCompositeID);
-	TestNull("Non-existent message should return nullptr", NonExistentData);
+	TestFalse("Non-existent message should not be found", Repository->TryGetMessageData(NonExistentCompositeID, MessageData));
 	
 	// Test 6: Test composite ID format with different separators (should use dot)
 	const FString ChannelWithDot = TEXT("channel.with.dots");
 	const FString Timetoken = TEXT("12345678901234567");
 	const FString CompositeIDWithDots = FString::Printf(TEXT("%s.%s"), *ChannelWithDot, *Timetoken);
 	Repository->RegisterMessage(CompositeIDWithDots);
-	FPubnubChatInternalMessage* DataWithDots = Repository->GetMessageData(CompositeIDWithDots);
-	TestNotNull("Message with dots in channel ID should work", DataWithDots);
-	if(DataWithDots)
-	{
-		TestEqual("Composite ID should preserve channel with dots", DataWithDots->MessageID, CompositeIDWithDots);
-	}
+	TestTrue("Message with dots in channel ID should work", Repository->TryGetMessageData(CompositeIDWithDots, MessageData));
 	Repository->UnregisterMessage(CompositeIDWithDots);
 	
 	return true;
@@ -664,23 +598,19 @@ bool FPubnubChatRepositoryMessageActionsTest::RunTest(const FString& Parameters)
 	Repository->UpdateMessageData(CompositeMessageID, TestData);
 	
 	// Verify actions are stored
-	FPubnubChatInternalMessage* MessageData = Repository->GetMessageData(CompositeMessageID);
-	TestNotNull("Message data should exist", MessageData);
+	FPubnubChatMessageData MessageData;
+	TestTrue("Message data should exist", Repository->TryGetMessageData(CompositeMessageID, MessageData));
+	TestEqual("MessageActions count should match", MessageData.MessageActions.Num(), 2);
 	
-	if(MessageData)
+	if(MessageData.MessageActions.Num() >= 2)
 	{
-		TestEqual("MessageActions count should match", MessageData->MessageData.MessageActions.Num(), 2);
+		TestEqual("First action Type should match", MessageData.MessageActions[0].Type, Action1.Type);
+		TestEqual("First action Value should match", MessageData.MessageActions[0].Value, Action1.Value);
+		TestEqual("First action UserID should match", MessageData.MessageActions[0].UserID, Action1.UserID);
 		
-		if(MessageData->MessageData.MessageActions.Num() >= 2)
-		{
-			TestEqual("First action Type should match", MessageData->MessageData.MessageActions[0].Type, Action1.Type);
-			TestEqual("First action Value should match", MessageData->MessageData.MessageActions[0].Value, Action1.Value);
-			TestEqual("First action UserID should match", MessageData->MessageData.MessageActions[0].UserID, Action1.UserID);
-			
-			TestEqual("Second action Type should match", MessageData->MessageData.MessageActions[1].Type, Action2.Type);
-			TestEqual("Second action Value should match", MessageData->MessageData.MessageActions[1].Value, Action2.Value);
-			TestEqual("Second action UserID should match", MessageData->MessageData.MessageActions[1].UserID, Action2.UserID);
-		}
+		TestEqual("Second action Type should match", MessageData.MessageActions[1].Type, Action2.Type);
+		TestEqual("Second action Value should match", MessageData.MessageActions[1].Value, Action2.Value);
+		TestEqual("Second action UserID should match", MessageData.MessageActions[1].UserID, Action2.UserID);
 	}
 	
 	return true;
@@ -717,26 +647,28 @@ bool FPubnubChatRepositoryClearAllTest::RunTest(const FString& Parameters)
 	Repository->RegisterMessage(CompositeMessageID2);
 	
 	// Verify data exists
-	TestNotNull("User1 data should exist", Repository->GetUserData(TestUserID));
-	TestNotNull("User2 data should exist", Repository->GetUserData(TEXT("test_user_2")));
-	TestNotNull("Channel1 data should exist", Repository->GetChannelData(TestChannelID));
-	TestNotNull("Channel2 data should exist", Repository->GetChannelData(TEXT("test_channel_2")));
-	TestNotNull("Message1 data should exist", Repository->GetMessageData(CompositeMessageID1));
-	TestNotNull("Message2 data should exist", Repository->GetMessageData(CompositeMessageID2));
+	FPubnubChatUserData UserData;
+	FPubnubChatChannelData ChannelData;
+	FPubnubChatMessageData MessageData;
+	TestTrue("User1 data should exist", Repository->TryGetUserData(TestUserID, UserData));
+	TestTrue("User2 data should exist", Repository->TryGetUserData(TEXT("test_user_2"), UserData));
+	TestTrue("Channel1 data should exist", Repository->TryGetChannelData(TestChannelID, ChannelData));
+	TestTrue("Channel2 data should exist", Repository->TryGetChannelData(TEXT("test_channel_2"), ChannelData));
+	TestTrue("Message1 data should exist", Repository->TryGetMessageData(CompositeMessageID1, MessageData));
+	TestTrue("Message2 data should exist", Repository->TryGetMessageData(CompositeMessageID2, MessageData));
 	
 	// Clear all
 	Repository->ClearAll();
 	
 	// Verify all data is cleared
-	TestNull("User1 data should be cleared", Repository->GetUserData(TestUserID));
-	TestNull("User2 data should be cleared", Repository->GetUserData(TEXT("test_user_2")));
-	TestNull("Channel1 data should be cleared", Repository->GetChannelData(TestChannelID));
-	TestNull("Channel2 data should be cleared", Repository->GetChannelData(TEXT("test_channel_2")));
-	TestNull("Message1 data should be cleared", Repository->GetMessageData(CompositeMessageID1));
-	TestNull("Message2 data should be cleared", Repository->GetMessageData(CompositeMessageID2));
+	TestFalse("User1 data should be cleared", Repository->TryGetUserData(TestUserID, UserData));
+	TestFalse("User2 data should be cleared", Repository->TryGetUserData(TEXT("test_user_2"), UserData));
+	TestFalse("Channel1 data should be cleared", Repository->TryGetChannelData(TestChannelID, ChannelData));
+	TestFalse("Channel2 data should be cleared", Repository->TryGetChannelData(TEXT("test_channel_2"), ChannelData));
+	TestFalse("Message1 data should be cleared", Repository->TryGetMessageData(CompositeMessageID1, MessageData));
+	TestFalse("Message2 data should be cleared", Repository->TryGetMessageData(CompositeMessageID2, MessageData));
 	
 	return true;
 }
 
 #endif // WITH_DEV_AUTOMATION_TESTS
-


### PR DESCRIPTION
fix: Fix dangling pointer race in `PubnubChatObjectsRepository` getters.

refactor: remove leftover `bEnableExceptions`

refactor: Add proper JSON serialization in places where unescaped `FString::Printf` was used