### PR TITLE
Add Unreal Engine versions to GitHub release distribution

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -150,7 +150,7 @@ sdks:
                     minimum-ue-version:
                       - 5.0
                     maximum-ue-version:
-                      - 5.6
+                      - 5.7
 
 
 supported-platforms:

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -146,6 +146,11 @@ sdks:
                       - Windows 11 Pro
                     target-architecture:
                       - x86-64
+                supported-unreal-engine-versions:
+                    minimum-ue-version:
+                      - 5.0
+                    maximum-ue-version:
+                      - 5.6
 
 
 supported-platforms:


### PR DESCRIPTION
## Summary

Adds a `supported-unreal-engine-versions` block (`minimum-ue-version` / `maximum-ue-version`, 5.0 / 5.6) to the GitHub release distribution in `.pubnub.yml`.

## Why

On the [Unreal Chat SDK Platform Support page](https://www.pubnub.com/docs/chat/unreal-chat-sdk/build/platform-support), the "Supported Unreal Engine Versions" section was not rendered at all, because the GitHub release distribution had no `supported-unreal-engine-versions` block.

With this change the section now appears and shows only the standard "Minimum UE Version" / "Maximum UE Version" columns.

> [!NOTE]
> The `minimum/maximum-ue-version` values (5.0 / 5.6) match the Unreal Engine SDK. Please confirm they are correct for the Unreal Chat SDK GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)